### PR TITLE
Straws v3

### DIFF
--- a/sandbox/straws/common.py
+++ b/sandbox/straws/common.py
@@ -19,6 +19,7 @@ import numpy as np
 import os
 
 METADATA_FILE = 'metadata.json'
+STRAW_VERSION = '3.0.0'
 
 def makeStrawName(path, sector, camera, ccd, col, row):
     """Constructh the straw name

--- a/sandbox/straws/common.py
+++ b/sandbox/straws/common.py
@@ -49,7 +49,7 @@ def makeStrawName(path, sector, camera, ccd, col, row):
 def getMetadataPath(path, sector, camera, ccd):
     fn = os.path.join(path, 
                       "sector%02i" %(sector),
-                      "camera%02i" %(camera),
+                      "camera%i" %(camera),
                       "ccd%i" %(ccd),
                       METADATA_FILE)
     return fn

--- a/sandbox/straws/common.py
+++ b/sandbox/straws/common.py
@@ -46,6 +46,15 @@ def makeStrawName(path, sector, camera, ccd, col, row):
     return path, fn
 
 
+def getMetadataPath(path, sector, camera, ccd):
+    fn = os.path.join(path, 
+                      "sector%02i" %(sector),
+                      "camera%02i" %(camera),
+                      "ccd%i" %(ccd),
+                      METADATA_FILE)
+    return fn
+
+
 def roundToNearestBelow(x, level):
     """Round a number down to the nearest round number
 

--- a/sandbox/straws/loadstraws.py
+++ b/sandbox/straws/loadstraws.py
@@ -40,8 +40,8 @@ class LoadTessCube(object):
     def __repr__(self):
         return "<TessCube object for sector %s. Data at %s>" %(self.sector, self.path)
 
-    def __call__(self, camera, ccd, col, row):
-        return self.get(camera, ccd, col, row, min_pix_size=20)
+    def __call__(self, col, row):
+        return self.get(col, row, min_pix_size=20)
 
     def loadMetadata(self):
         """Load metadata on the straws stored in `path`
@@ -90,7 +90,7 @@ class LoadTessCube(object):
         """Return a integers from zero to length of datacube"""
         return np.arange(self.nCadences, dtype=int)
     
-    def get(self, camera, ccd, col, row, min_size_pix=None):
+    def get(self, col, row, min_size_pix=None):
         """Get a data cube
 
         The data cube is garaunteed to be square and at least `min_size_pix`
@@ -101,15 +101,13 @@ class LoadTessCube(object):
 
         Inputs
         -------------
-        camera, ccd, col, row
-            (int) Properties of the straw. col and row refer to coordinates of
-            the bottom-left corner of the straw.
+        col, row
+            (int) Location on CCD to load a straw for
 
         Optional Inputs
         -----------------
         min_size_pix
             (int) Minimum width and height of the returned datacube
-
 
         Returns
         -----------
@@ -132,7 +130,7 @@ class LoadTessCube(object):
         ds = self.strawSize
         for i in range(c0, c1, ds):
             for j in range(r0, r1, ds):
-                straw = self.getStraw(camera, ccd, i, j)
+                straw = self.getStraw(i, j)
                 
                 assert straw.shape == (self.nCadences, ds, ds)
 

--- a/sandbox/straws/loadstraws.py
+++ b/sandbox/straws/loadstraws.py
@@ -65,7 +65,7 @@ class LoadTessCube(object):
             %(self.sector, self.camera, self.ccd, self.path)
 
     def __call__(self, col, row):
-        return self.get(col, row, min_pix_size=20)
+        return self.get(col, row, min_size_pix=20)
 
     def loadMetadata(self):
         """Load metadata on the straws stored in `path`

--- a/sandbox/straws/loadstraws.py
+++ b/sandbox/straws/loadstraws.py
@@ -39,7 +39,7 @@ class LoadTessCube(object):
         return "<TessCube object for sector %s. Data at %s>" %(self.sector, self.path)
 
     def __call__(self, camera, ccd, col, row):
-        return self.get(camera, ccd, col, row, 20)
+        return self.get(camera, ccd, col, row, min_pix_size=20)
 
     def loadMetadata(self):
         """Load metadata on the straws stored in `path`
@@ -53,6 +53,12 @@ class LoadTessCube(object):
             props = json.load(fp)
 
         assert self.sector == props['sector']
+        
+        dataver = props['__straw_version__']
+        expectver = common.STRAW_VERSION
+        if  dataver !=  expectver:
+            raise ValueError("Expected version %s straws, got version %s" %(expectver, dataver))
+            
         self.setMetadataFromDict(props)
         
     def setMetadataFromDict(self, props):

--- a/sandbox/straws/loadstraws.py
+++ b/sandbox/straws/loadstraws.py
@@ -27,12 +27,14 @@ class LoadTessCube(object):
     Load a datacube of TESS imagery from straws stored on disk.
     """
 
-    def __init__(self, path, sector):
+    def __init__(self, path, sector, camera, ccd):
 
         #Set path to None for some testing
         if path is not None:
             self.path = path
             self.sector = sector
+            self.camera = camera
+            self.ccd = ccd
             self.loadMetadata()
 
     def __repr__(self):
@@ -47,22 +49,26 @@ class LoadTessCube(object):
         Metadata is stored in a json file and contains details like ccd sizes,
         number of cadences, strawsize, etc.
         """
-        sectorStr = "sector%02i" %(self.sector)
-        fn = os.path.join(self.path, sectorStr, common.METADATA_FILE)
+        fn = common.getMetadataPath(self.outPath, 
+                                    self.sector,
+                                    self.camera,
+                                    self.ccd)
+
         with open(fn) as fp:
             props = json.load(fp)
 
-        assert self.sector == props['sector']
-        
         dataver = props['__straw_version__']
         expectver = common.STRAW_VERSION
         if  dataver !=  expectver:
             raise ValueError("Expected version %s straws, got version %s" %(expectver, dataver))
+
+        assert self.sector == props['sector']
+        assert self.camera == props['camera']
+        assert self.ccd == props['ccd']
             
         self.setMetadataFromDict(props)
         
     def setMetadataFromDict(self, props):
-
         self.__dict__.update(props)
         self.nCols, self.nRows = self.nColsRows
         self.nCadences = len(self.datestampList)

--- a/sandbox/straws/makestraws.py
+++ b/sandbox/straws/makestraws.py
@@ -65,7 +65,7 @@ import datetime
 import inspect
 import json
 
-from common import  METADATA_FILE, STRAW_VERSION
+from common import  STRAW_VERSION
 import common
 
 class MakeTessStraw(object):

--- a/sandbox/straws/makestraws.py
+++ b/sandbox/straws/makestraws.py
@@ -65,7 +65,7 @@ import datetime
 import inspect
 import json
 
-from common import  METADATA_FILE
+from common import  METADATA_FILE, STRAW_VERSION
 from common import makeStrawName
 
 
@@ -263,6 +263,7 @@ class MakeTessStraw(object):
         params['__lineno__'] = lineno
         params['__date__'] = str(datetime.datetime.now())
         params['__user__'] = os.environ['USER']
+        params['__straw_version__'] = STRAW_VERSION
         
         params.update(self.__dict__)
         text = json.dumps(params, indent=2)

--- a/sandbox/straws/makestraws.py
+++ b/sandbox/straws/makestraws.py
@@ -66,8 +66,7 @@ import inspect
 import json
 
 from common import  METADATA_FILE, STRAW_VERSION
-from common import makeStrawName
-
+import common
 
 class MakeTessStraw(object):
     def __init__(self, ffiPath, outPath, sector, camera, ccd):
@@ -201,12 +200,12 @@ class MakeTessStraw(object):
             (int) Properties of the straw. col and row refer to coordinates of
             the bottom-left corner of the straw.
         """
-        path, fn = makeStrawName(self.outPath,
-                                 self.sector,
-                                 camera,
-                                 ccd,
-                                 col,
-                                 row)
+        path, fn = common.makeStrawName(self.outPath,
+                                        self.sector,
+                                        camera,
+                                        ccd,
+                                        col,
+                                        row)
 
         if not os.path.exists(path):
             os.makedirs(path)
@@ -253,8 +252,11 @@ class MakeTessStraw(object):
         """Save a metadata file to a local filestore
         """
 
-        fn = os.path.join(self.outPath, "sector%02i" %(self.sector), METADATA_FILE)
-
+        fn = common.getMetadataPath(self.outPath, 
+                                    self.sector,
+                                    self.camera,
+                                    self.ccd)
+            
         frame = inspect.currentframe().f_back
         (filename, lineno, funcname, _, _) = inspect.getframeinfo(frame)
         params = collections.OrderedDict()

--- a/sandbox/straws/test_loadstraws.py
+++ b/sandbox/straws/test_loadstraws.py
@@ -34,7 +34,7 @@ class MonkeyLoadCube(loadstraws.LoadTessCube):
     more information.
     """
 
-    def getStraw(self, camera, ccd, col, row):
+    def getStraw(self, col, row):
 #        print(camera, ccd, col, row)
         shape = (self.nCadences, self.strawSize, self.strawSize)
         straw = np.zeros(shape)
@@ -51,13 +51,13 @@ def test_loadstraws_local():
     row = 255.1
     path = "testdata/smoke"
 
-    cubeObj = loadstraws.LoadTessCube(path, sector)
-    cube, cube_col, cube_row = cubeObj.get(camera, ccd, col, row, 
-                                           min_size_pix = 5)
+    cubeObj = loadstraws.LoadTessCube(path, sector, camera, ccd)
+    cube, cube_col, cube_row = cubeObj.get(col, row, min_size_pix = 5)
     assert cube.shape == (2,10,5), cube.shape
 
 
 def test_loadstraws_s3():
+    """Will fail until I update the remote s3 metadata.json"""
         
     #Faking it for testing
     sector = 1
@@ -67,17 +67,16 @@ def test_loadstraws_s3():
     row = 255.1
     path = ""
     bucket = "tess-straws"
-    cubeObj = loadstraws.LoadTessCubeS3(bucket, path, sector)
-    cube, cube_col, cube_row = cubeObj.get(camera, ccd, col, row, 
-                                           min_size_pix = 40)
+    cubeObj = loadstraws.LoadTessCubeS3(bucket, path, sector, camera, ccd)
+    cube, cube_col, cube_row = cubeObj.get(col, row, min_size_pix = 40)
     print(cube.shape)
 
 
 def test_bug1():
     """Fixing a bug reported by Susan in testing"""
-    obj = MonkeyLoadCube('./testdata/bug1', 1)
+    obj = MonkeyLoadCube('./testdata/bug1', 1, 1, 2)
 
-    cube, col, row = obj.get(1, 1, 221, 250, min_size_pix=40)
+    cube, col, row = obj.get( 221, 250, min_size_pix=40)
 
     nCad = obj.nCadences
     expect = (nCad, 100, 50)
@@ -87,7 +86,7 @@ def test_bug1():
 
 def test_pickABox():
 
-    obj = loadstraws.LoadTessCube(None, 0)
+    obj = loadstraws.LoadTessCube(None, 0, 1, 2)
     obj.nCols = 600
     obj.nRows = 700
     obj.nCadences = 40

--- a/sandbox/straws/testdata/bug1/sector01/camera1/ccd2/metadata.json
+++ b/sandbox/straws/testdata/bug1/sector01/camera1/ccd2/metadata.json
@@ -1,4 +1,5 @@
 {
+  "__straw_version__": "3.0.0",
   "outPath": "/home/sthomp/TESS/s0001-straws/",
   "ffiPath": "/home/sthomp/TESS/s0001/",
   "sector": 1,

--- a/sandbox/straws/testdata/smoke/sector01/camera1/ccd1/metadata.json
+++ b/sandbox/straws/testdata/smoke/sector01/camera1/ccd1/metadata.json
@@ -1,10 +1,11 @@
 {
+  "__straw_version__": "3.0.0",
   "comment": "A dummy straw collection used for testing",
   "outPath": "/home/sthomp/TESS/s0001-straws/",
   "ffiPath": "/home/sthomp/TESS/s0001/",
   "sector": 1,
   "camera": 1,
-  "ccd": 2,
+  "ccd": 1,
   "strawSize": 5,
   "dataVersion": 120,
   "datestampList": [


### PR DESCRIPTION
makestraws, and loadTessDataCube now expect each sector/camera/ccd directory to have its own metadata file, instead of having one per sector.

This code isn't ready for merge until the last unit test passes, which requires moving things around on s3.